### PR TITLE
Update `requirements.txt` File

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.14.3
+numpy>=1.14.3, < 1.20
 pandas>=0.22
 tensorflow==2.2
 h5py>=2.8
@@ -9,3 +9,4 @@ tqdm>=4.26
 xarray>=0.11.2
 seaborn>=0.9
 openpyxl>=3.0
+protobuf<3.20


### PR DESCRIPTION

#### Changes Made
- Updated `requirements.txt` to add version constraints for `protobuf < 3.20` and `numpy < 1.20`, to avoid issues caused by deprecated functionalities in newer versions.
- Ensured that the project environment can now be set up using `pip install -r requirements.txt` without errors.
- The changes were tested on two different devices, and the project runs as expected on both.

#### Reasons for the Changes
- **Protobuf Version Issue**: 
    - When installing newer versions of `protobuf` (e.g., version 5.28.2), the following error occurs:
      ```
      If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.

      If you cannot immediately regenerate your protos, some other possible workarounds are:
        1. Downgrade the protobuf package to 3.20.x or lower.
        2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
      ```
    - To resolve this, I added a constraint to limit `protobuf` versions to `< 3.20` in the requirements list.

- **NumPy Version Issue**: 
    - When installing newer versions of `numpy`, an error occurs in TensorFlow 2.2 due to deprecated functionality:
      ```
      AttributeError: module 'numpy' has no attribute 'object'.

      `np.object` was a deprecated alias for the builtin `object`. To avoid this error in existing code, use `object` by itself. Doing this will not modify any behavior and is safe.
      ```
    - The alias was deprecated in NumPy 1.20, as noted in the release documentation: [NumPy 1.20 Deprecations](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations).
    - To fix this, I updated the version requirement to `numpy>=1.14.3, < 1.20`.

#### Testing
- The updated dependencies were tested on two devices, and the environment configured using `pip install -r requirements.txt` worked without any issues on both.

